### PR TITLE
Fix issues, clarify directions, add multitransfer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.ini
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 # Steam-Apps-Manager
-Steam-Apps-Manager is a Windows software to move Steam apps between library folders (usually one per disk).
+
+Steam Apps Manager is a Windows desktop application to move Steam apps between Steam library folders.
 
 You can download it using the Releases tab above.
 
 # Features
-- Automagically detects all of your games
-- See where each game is installed and how much it weights
-- Move games between each of your Steam library folders
-- Create new Steam library folders directly within the software (so that you don't have to open Steam and install a game to create one on another disk)
-- Import a Steam library folder from another disk (for instance if you plug your old PC's hard drive into your new one and doesn't want to lose your games)
- 
-# How to use it ?
 
-##To move a game
+- Automatically detects all of your games from your Steam libraries
+- See where each game is installed and its file size
+- Move games between each of your Steam library folders
+- Create new Steam library folders directly, without needing to open Steam
+- Import a Steam library folder from another disk
+ 
+# Usage 
+
+## Moving a game
+
 - Open the software
 - Select the game that you want to move
 - Choose where you want to move it
-    - If you already have a Steam library folder in the target disk, just choose it
-    - If not, create one where you want to
-- Done
+    - If you already have a Steam library folder in the target disk, select it from the application
+    - If not, create the desired Steam library folder
 
-##To import a Steam library folder
+## Importing a Steam library folder
+
 - Open the software
-- Click on the Import an existing library button
-- Select the folder 
-- Done
-  
- 
+- Click on the "Import an existing library"
+- Select the root Steam library folder, which contains the `/steamapps/` folder

--- a/Steam Apps Manager/GUI/MainWindow.xaml
+++ b/Steam Apps Manager/GUI/MainWindow.xaml
@@ -12,22 +12,22 @@
             <ColumnDefinition Width="251*"/>
         </Grid.ColumnDefinitions>
         <ListBox x:Name="listBox" Height="149" Margin="16,10,16,0" VerticalAlignment="Top" Grid.ColumnSpan="2" SelectionChanged="listBox_SelectionChanged"/>
-        <GroupBox x:Name="groupBox" Margin="15,165,16,0" VerticalAlignment="Top" Height="142" Grid.ColumnSpan="2" HorizontalContentAlignment="Center" Header="App informations">
+        <GroupBox x:Name="groupBox" Margin="15,165,16,0" VerticalAlignment="Top" Height="142" Grid.ColumnSpan="2" HorizontalContentAlignment="Center" Header="App information">
             <Grid Height="135" Width="587" Margin="10,10,10,-12">
                 <Grid x:Name="welcomeLabelGrid"  Height="129" Margin="0,0,10,0">
-                    <Label x:Name="label" Content="Please select an app in the list." HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0,-12,0,0"/>
+                    <Label x:Name="label" Content="Please select an app from the list." HorizontalAlignment="Center" VerticalAlignment="Center" Margin="184,46,207,57"/>
                 </Grid>
                 <StackPanel x:Name="infosGrid" Height="129" Margin="0,0,10,0"  Visibility="Hidden">
                     <Label x:Name="appNameLabel" Content="App name" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0" FontWeight="Bold"/>
                     <Label x:Name="appPathLabel" Content="Currently installed in C:\Program Files (x86)\Steam\steamapps" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0" FontStyle="Italic"/>
-                    <Label x:Name="appSizeLabel" Content="Size on disk : n/a" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0" FontStyle="Italic"/>
+                    <Label x:Name="appSizeLabel" Content="Size on disk: n/a" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0" FontStyle="Italic"/>
                     <Label x:Name="appStatusLabel" Content="This app needs to be updated before moving it. Please open Steam and update it." HorizontalAlignment="Center" VerticalAlignment="Center" Margin="0" FontWeight="Bold"/>
-                    <Button x:Name="appMoveButton" Content="Move this app" HorizontalAlignment="Center" VerticalAlignment="Center" Click="appMoveButton_Click"/>
+                    <Button x:Name="appMoveButton" Content="Move this app" HorizontalAlignment="Center" VerticalAlignment="Center" Click="appMoveButton_Click" Margin="223,0,223,0" Width="105"/>
                 </StackPanel>
             </Grid>
         </GroupBox>
-        <Label x:Name="label1" Content="Steam Apps Manager v1.0.1 - by natinusala" HorizontalAlignment="Left" Margin="256,309,0,0" VerticalAlignment="Top" Width="230" Grid.Column="1" HorizontalContentAlignment="Right"/>
-        <Button x:Name="importButton" Content="Import an existing library..." Grid.Column="1" HorizontalAlignment="Left" Margin="90,312,0,0" VerticalAlignment="Top" Width="161" Click="importButton_Click"/>
+        <Label x:Name="label1" Content="Steam Apps Manager v1.1 - by natinusala" HorizontalAlignment="Left" Margin="256,309,0,0" VerticalAlignment="Top" Width="230" Grid.Column="1" HorizontalContentAlignment="Right"/>
+        <Button x:Name="importButton" Content="Import an existing library" Grid.Column="1" HorizontalAlignment="Left" Margin="90,312,0,0" VerticalAlignment="Top" Width="161" Click="importButton_Click"/>
 
     </Grid>
 </Window>

--- a/Steam Apps Manager/GUI/MainWindow.xaml
+++ b/Steam Apps Manager/GUI/MainWindow.xaml
@@ -11,7 +11,7 @@
             <ColumnDefinition Width="65*"/>
             <ColumnDefinition Width="251*"/>
         </Grid.ColumnDefinitions>
-        <ListBox x:Name="listBox" Height="149" Margin="16,10,16,0" VerticalAlignment="Top" Grid.ColumnSpan="2" SelectionChanged="listBox_SelectionChanged"/>
+        <ListBox x:Name="listBox" Height="149" Margin="16,10,16,0" VerticalAlignment="Top" Grid.ColumnSpan="2" SelectionChanged="listBox_SelectionChanged" SelectionMode="Extended"/>
         <GroupBox x:Name="groupBox" Margin="15,165,16,0" VerticalAlignment="Top" Height="142" Grid.ColumnSpan="2" HorizontalContentAlignment="Center" Header="App information">
             <Grid Height="135" Width="587" Margin="10,10,10,-12">
                 <Grid x:Name="welcomeLabelGrid"  Height="129" Margin="0,0,10,0">

--- a/Steam Apps Manager/GUI/MoveDialog.xaml
+++ b/Steam Apps Manager/GUI/MoveDialog.xaml
@@ -11,7 +11,7 @@
         <Grid x:Name="folderSelectGrid">
             <Label x:Name="appNameLabel" Content="Move xxx to :" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" FontWeight="Bold"/>
             <ComboBox x:Name="comboBox" Margin="10,41,0,0" VerticalAlignment="Top" Width="565" HorizontalAlignment="Left"/>
-            <Button x:Name="button" Content="Move it now" HorizontalAlignment="Left" Margin="10,68,0,0" VerticalAlignment="Top" Width="565" Click="button_Click"/>
+            <Button x:Name="button" Content="Move now" HorizontalAlignment="Left" Margin="10,68,0,0" VerticalAlignment="Top" Width="565" Click="button_Click"/>
         </Grid>
         <Grid x:Name="movingGrid" Visibility="Collapsed">
             <Label x:Name="appNameMovingLabel" Content="Moving xxx to xxx :" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" FontWeight="Bold"/>

--- a/Steam Apps Manager/GUI/MoveDialog.xaml.cs
+++ b/Steam Apps Manager/GUI/MoveDialog.xaml.cs
@@ -33,7 +33,7 @@ namespace Steam_Apps_Manager.GUI
             InitializeComponent();
 
             this.Title = "Move " + steamApp.appName;
-            this.appNameLabel.Content = "Move " + steamApp.appName + " to :";
+            this.appNameLabel.Content = "Move " + steamApp.appName + " to:";
 
             Refresh();
 
@@ -55,7 +55,8 @@ namespace Steam_Apps_Manager.GUI
 
         private void worker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
-            System.Windows.MessageBox.Show("The app has been successfully moved !\nRun a game cache files verification from Steam if the game doesn't work properly.", "Information", MessageBoxButton.OK, MessageBoxImage.Information);
+            System.Windows.MessageBox.Show(steamApp.appName + " has been successfully moved!\n" +
+                "Select \"verify integrity of game files\" via Steam if the game doesn't run.", "Information", MessageBoxButton.OK, MessageBoxImage.Information);
             this.Close();
         }
 
@@ -120,7 +121,7 @@ namespace Steam_Apps_Manager.GUI
             }
 
             //Beginning
-            this.appNameMovingLabel.Content = "Moving " + steamApp.appName + " to " + selectedFolder.path + "\\...";
+            this.appNameMovingLabel.Content = "Moving " + steamApp.appName + " to " + selectedFolder.path + "\\";
 
             this.progressBar.Value = 0;
             this.progressBar.Maximum = 1000;

--- a/Steam Apps Manager/GUI/MoveDialog.xaml.cs
+++ b/Steam Apps Manager/GUI/MoveDialog.xaml.cs
@@ -15,13 +15,14 @@ namespace Steam_Apps_Manager.GUI
 
     public partial class MoveDialog : Window
     {
-        private SteamUtils.App steamApp;
+        private List<SteamUtils.App> steamApps;
         private List<LibraryFolder> libraryFolders;
         private BackgroundWorker worker;
+        private string formattedGameList;
 
-        public MoveDialog(SteamUtils.App steamApp)
+        public MoveDialog(List<SteamUtils.App> steamApps)
         {
-            this.steamApp = steamApp;
+            this.steamApps = steamApps;
             this.libraryFolders = new List<LibraryFolder>();
 
             this.worker = new BackgroundWorker();
@@ -32,8 +33,9 @@ namespace Steam_Apps_Manager.GUI
 
             InitializeComponent();
 
-            this.Title = "Move " + steamApp.appName;
-            this.appNameLabel.Content = "Move " + steamApp.appName + " to:";
+            this.formattedGameList = Utils.FormatGameList(steamApps, 60);
+            this.Title = "Move " + this.formattedGameList;
+            this.appNameLabel.Content = "Move " + this.formattedGameList + " to:";
 
             Refresh();
 
@@ -41,22 +43,32 @@ namespace Steam_Apps_Manager.GUI
 
         private void worker_DoWork(object sender, DoWorkEventArgs e)
         {
-            //Preparation
-            string oldManifestPath = steamApp.GetManifestPath();
-            string newManifestPath = selectedFolder.GetManifestPathForAppId(steamApp.appId);
+            foreach (SteamUtils.App steamApp in steamApps)
+            {
+                //Preparation
+                string oldManifestPath = steamApp.GetManifestPath();
+                string newManifestPath = selectedFolder.GetManifestPathForAppId(steamApp.appId);
 
-            //Moving the manifest
-            Directory.CreateDirectory(newManifestPath.Substring(0, newManifestPath.LastIndexOf('\\')));
-            File.Move(oldManifestPath, newManifestPath);
+                //Moving the manifest
+                Directory.CreateDirectory(newManifestPath.Substring(0, newManifestPath.LastIndexOf('\\')));
+                try
+                {
+                    File.Move(oldManifestPath, newManifestPath);
+                }
+                catch (FileNotFoundException)
+                {
 
-            //Moving the game  
-            steamApp.MoveAppFiles(selectedFolder, worker);
+                }
+
+                //Moving the game  
+                steamApp.MoveAppFiles(selectedFolder, worker);
+            }
         }
 
         private void worker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
-            System.Windows.MessageBox.Show(steamApp.appName + " has been successfully moved!\n" +
-                "Select \"verify integrity of game files\" via Steam if the game doesn't run.", "Information", MessageBoxButton.OK, MessageBoxImage.Information);
+            System.Windows.MessageBox.Show(this.formattedGameList + " have been successfully moved!\n" +
+                "Select \"verify integrity of game files\" via Steam if the game(s) do not run.", "Information", MessageBoxButton.OK, MessageBoxImage.Information);
             this.Close();
         }
 
@@ -84,7 +96,7 @@ namespace Steam_Apps_Manager.GUI
 
             foreach (LibraryFolder folder in tempLibraryFolders)
             {
-                if (folder.path != steamApp.folder.path)
+                if (folder.path != steamApps[0].folder.path)
                 {
                     this.comboBox.Items.Add(folder.path);
                     libraryFolders.Add(folder);
@@ -113,15 +125,20 @@ namespace Steam_Apps_Manager.GUI
                 selectedFolder = libraryFolders[this.comboBox.SelectedIndex];
             }
 
-            if (selectedFolder.GetAvailableFreeDiskSpace() <= steamApp.sizeOnDisk)
+            long totalBytes = 0;
+
+            foreach(SteamUtils.App app in this.steamApps)
+                totalBytes += app.sizeOnDisk;
+
+            if (selectedFolder.GetAvailableFreeDiskSpace() <= totalBytes)
             {
-                System.Windows.MessageBox.Show("You don't have enough free space on disk " + selectedFolder.path[0] + " to move the game.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                System.Windows.MessageBox.Show("You don't have enough free space on disk " + selectedFolder.path[0] + " to move the game(s).", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                 Refresh();
                 return;
             }
 
             //Beginning
-            this.appNameMovingLabel.Content = "Moving " + steamApp.appName + " to " + selectedFolder.path + "\\";
+            this.appNameMovingLabel.Content = "Moving " + this.formattedGameList + " to " + selectedFolder.path + "\\";
 
             this.progressBar.Value = 0;
             this.progressBar.Maximum = 1000;

--- a/Steam Apps Manager/SteamUtils/App.cs
+++ b/Steam Apps Manager/SteamUtils/App.cs
@@ -40,14 +40,10 @@ namespace Steam_Apps_Manager.SteamUtils
             this.fullInstallDir = this.folder.path + "\\common\\" + installDir;
             this.appState = int.Parse((string)appState["StateFlags"]);
 
-            if (appState.ContainsKey("SizeOnDisk"))
-            {
-                sizeOnDisk = long.Parse(((string)appState["SizeOnDisk"]));
-            }
-            else
-            {
-                this.sizeOnDisk = 0;
-            }
+            this.sizeOnDisk = Utils.GetDirectorySize(this.fullInstallDir);
+
+            Console.WriteLine(this.fullInstallDir);
+            Console.WriteLine("Size of " + this.appName + " is " + this.sizeOnDisk);
         }
 
         public string GetManifestPath()

--- a/Steam Apps Manager/SteamUtils/App.cs
+++ b/Steam Apps Manager/SteamUtils/App.cs
@@ -40,10 +40,15 @@ namespace Steam_Apps_Manager.SteamUtils
             this.fullInstallDir = this.folder.path + "\\common\\" + installDir;
             this.appState = int.Parse((string)appState["StateFlags"]);
 
-            this.sizeOnDisk = Utils.GetDirectorySize(this.fullInstallDir);
-
-            Console.WriteLine(this.fullInstallDir);
-            Console.WriteLine("Size of " + this.appName + " is " + this.sizeOnDisk);
+            if (appState.ContainsKey("SizeOnDisk"))
+            {
+                sizeOnDisk = long.Parse(((string)appState["SizeOnDisk"]));
+            }
+            else
+            {
+                this.sizeOnDisk = Utils.GetDirectorySize(this.fullInstallDir);
+            }
+            
         }
 
         public string GetManifestPath()
@@ -58,32 +63,39 @@ namespace Steam_Apps_Manager.SteamUtils
 
         public void MoveAppFiles(LibraryFolder newFolder, BackgroundWorker worker)
         {
-            string newFullDir = newFolder.path + "\\common\\" + installDir;
-
-            foreach(string path in Directory.GetDirectories(this.fullInstallDir, "*", SearchOption.AllDirectories))
+            try
             {
-                Directory.CreateDirectory(path.Replace(fullInstallDir, newFullDir));
-            }
+                string newFullDir = newFolder.path + "\\common\\" + installDir;
 
-            foreach (string file in Directory.GetFiles(fullInstallDir, "*.*", SearchOption.AllDirectories))
-            {
-                FileInfo info = new FileInfo(file);
-                long fileSize = info.Length;
-
-                File.Move(file, file.Replace(fullInstallDir, newFullDir));
-
-                if (worker != null && fileSize != 0)
+                foreach (string path in Directory.GetDirectories(this.fullInstallDir, "*", SearchOption.AllDirectories))
                 {
-                    worker.ReportProgress((int)Math.Round(((double)fileSize / (double)sizeOnDisk) * 1000.0f));
+                    Directory.CreateDirectory(path.Replace(fullInstallDir, newFullDir));
                 }
+
+                foreach (string file in Directory.GetFiles(fullInstallDir, "*.*", SearchOption.AllDirectories))
+                {
+                    FileInfo info = new FileInfo(file);
+                    long fileSize = info.Length;
+
+                    File.Move(file, file.Replace(fullInstallDir, newFullDir));
+
+                    if (worker != null && fileSize != 0)
+                    {
+                        worker.ReportProgress((int)Math.Round(((double)fileSize / (double)sizeOnDisk) * 1000.0f));
+                    }
+                }
+
+                worker.ReportProgress(-1);
+
+                Directory.Delete(this.fullInstallDir, true);
+
+                this.folder = newFolder;
+                this.fullInstallDir = this.folder.path + "\\common\\" + installDir;
             }
-
-            worker.ReportProgress(-1);
-
-            Directory.Delete(this.fullInstallDir, true);
-
-            this.folder = newFolder;
-            this.fullInstallDir = this.folder.path + "\\common\\" + installDir;
+            catch (System.IO.DirectoryNotFoundException)
+            {
+                return;
+            }
         }
     }
 }

--- a/Steam Apps Manager/SteamUtils/LibraryFolder.cs
+++ b/Steam Apps Manager/SteamUtils/LibraryFolder.cs
@@ -50,7 +50,7 @@ namespace Steam_Apps_Manager.SteamUtils
 
         public static LibraryFolder CreateNew()
         {
-            System.Windows.MessageBox.Show("Please select a folder in which to create a new Steam library (steamapps will be created INTO this folder). It must be empty.", "Information", MessageBoxButton.OK, MessageBoxImage.Information);
+            System.Windows.MessageBox.Show("Please select an empty folder for your new Steam library.", "Information", MessageBoxButton.OK, MessageBoxImage.Information);
             FolderBrowserDialog dialog = new FolderBrowserDialog();
             DialogResult result = dialog.ShowDialog();
 

--- a/Steam Apps Manager/SteamUtils/Utils.cs
+++ b/Steam Apps Manager/SteamUtils/Utils.cs
@@ -26,6 +26,33 @@ namespace Steam_Apps_Manager.SteamUtils
             return GetBaseSteamAppsPath() + "\\libraryfolders.vdf";
         }
 
+        public static long GetDirectorySize(string path)
+        {
+            try
+            {
+                long totalBytes = 0;
+                DirectoryInfo rootDirectory = new DirectoryInfo(path);
+
+                FileInfo[] files = rootDirectory.GetFiles();
+
+                foreach (FileInfo file in files)
+                {
+                    totalBytes += file.Length;
+                }
+
+                DirectoryInfo[] directories = rootDirectory.GetDirectories();
+
+                foreach (DirectoryInfo directory in directories)
+                {
+                    totalBytes += GetDirectorySize(directory.FullName);
+                }
+
+                return totalBytes;
+            } catch(Exception e)
+            {
+                return 0;
+            }
+        }
 
         public static bool IsDirectoryEmpty(string path)
         {

--- a/Steam Apps Manager/SteamUtils/Utils.cs
+++ b/Steam Apps Manager/SteamUtils/Utils.cs
@@ -54,6 +54,29 @@ namespace Steam_Apps_Manager.SteamUtils
             }
         }
 
+        public static string FormatGameList(List<SteamUtils.App> games, int maxChars)
+        {
+            string formattedList = "";
+            int overflowAmount = 0;
+
+            foreach (SteamUtils.App app in games)
+            {
+                if (formattedList.Length + app.appName.Length + 13 <= maxChars)
+                    formattedList += ", " + app.appName;
+               
+                else overflowAmount++;
+            }
+
+            formattedList = formattedList.Substring(2);
+
+            if (overflowAmount > 0)
+                formattedList += " + " + overflowAmount + " game";
+            if (overflowAmount > 1)
+                formattedList += "s";
+
+            return formattedList;
+        }
+
         public static bool IsDirectoryEmpty(string path)
         {
             DirectoryInfo directory = new DirectoryInfo(path);


### PR DESCRIPTION
Major changes:
- Fixed #3 by implementing a method to manually scan file size,
- Corrected some grammatical issues in the application directions and the README
- Added a feature that allow users to select/transfer multiple games from the same Steam library folder directory. This should now make this tool more efficient than Steam's built-in method when moving multiple games across drives. 

Please let me know if you have any questions regarding these changes.